### PR TITLE
Secure chat image uploads against overwrite abuse

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -9,6 +9,7 @@ import {
 	insertPrivateChatMessage,
 	insertGroupChatMessage,
 } from '../controllers/chatController';
+import { protectedApi } from '../middleware/auth';
 import { uploadImg } from '../util/s3Connect';
 
 const router = Router();
@@ -18,7 +19,7 @@ router.post('/getGroupChatList', getGroupChatList);
 router.post('/getUnreadChatNoti', getUnReadChatNoti);
 router.post('/createChatGroup', createChatGroup);
 router.post('/getChatGroups', getChatGroups);
-router.post('/uploadChatImg', uploadImg, uploadChatImg);
+router.post('/uploadChatImg', protectedApi, uploadImg, uploadChatImg);
 router.post('/insertPrivateChatMessage', insertPrivateChatMessage);
 router.post('/insertGroupChatMessage', insertGroupChatMessage);
 

--- a/src/util/s3Connect.ts
+++ b/src/util/s3Connect.ts
@@ -33,8 +33,9 @@ const upload = multer({
 				imgArr.push(`${POSTDATA.dir}${file.originalname}`);
 				cb(null, `${POSTDATA.dir}${file.originalname}`);
 			} else {
-				imgArr.push(`${POSTDATA.dir}${file.originalname}`);
-				cb(null, `${POSTDATA.dir}${file.originalname}`);
+				const dateStr = Date.now();
+				imgArr.push(`${POSTDATA.dir}${dateStr}_${file.originalname}`);
+				cb(null, `${POSTDATA.dir}${dateStr}_${file.originalname}`);
 			}
 		},
 	}),


### PR DESCRIPTION
### Motivation
- A previously introduced change made S3 object keys predictable and added an unauthenticated chat image upload endpoint, allowing remote attackers to overwrite existing S3 objects (bucket uses public-read-write ACL). 

### Description
- Require authentication for chat image uploads by adding the `protectedApi` middleware to the `/uploadChatImg` route in `src/routes/chat.ts`. 
- Restore per-upload randomness for non-registration uploads by prefixing the uploaded filename with a timestamp in `src/util/s3Connect.ts` so keys are no longer fully user-controlled. 
- Preserve the original behavior for `REGISTER_USER` uploads to avoid changing registration image semantics. 
- Changes touch `src/routes/chat.ts` and `src/util/s3Connect.ts` only and are implemented minimally to mitigate the overwrite risk while preserving existing flows. 

### Testing
- Ran a TypeScript build with `npm run build`, which completed successfully. 
- Verified the modified routes and S3 key generation compile in the project TypeScript output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd19792e288332a0ad61184595a30a)